### PR TITLE
Cannot use noarch due to link scripts

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,8 +12,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  noarch: python
-  number: 1
+  number: 2
   script: python -m pip install --no-deps --ignore-installed .
 
 requirements:


### PR DESCRIPTION
It will not enable the extension with noarch